### PR TITLE
disable password authentication

### DIFF
--- a/deployment.azure.yaml.example
+++ b/deployment.azure.yaml.example
@@ -12,7 +12,9 @@ common:
     reg_code: GIVEN-CODE-TO-JOHN
     offer: sles-sap-15-sp2
     sku: gen2
-    
+    authorized_keys_file: /home/<user_name>/.ssh/authorized_keys
+    public_key_file: /home/<user_name>/.ssh/id_rsa.pub
+
 node:
     count: 3
 

--- a/terraform/azure/examiner.tf.j2
+++ b/terraform/azure/examiner.tf.j2
@@ -62,7 +62,12 @@ resource "azurerm_virtual_machine" "examiner_vm" {
     }
 
     os_profile_linux_config {
-        disable_password_authentication = false
+        disable_password_authentication = true
+
+        ssh_keys {
+            path     = "{{ examiner.authorized_keys_file }}"
+            key_data = file("{{ examiner.public_key_file }}")
+        }
     }
 
 

--- a/terraform/azure/iscsi.tf.j2
+++ b/terraform/azure/iscsi.tf.j2
@@ -69,7 +69,12 @@ resource "azurerm_virtual_machine" "iscsi_vm" {
     }
 
     os_profile_linux_config {
-        disable_password_authentication = false
+        disable_password_authentication = true
+
+        ssh_keys {
+            path     = "{{ iscsi.authorized_keys_file }}"
+            key_data = file("{{ iscsi.public_key_file }}")
+        }
     }
 
 

--- a/terraform/azure/node.tf.j2
+++ b/terraform/azure/node.tf.j2
@@ -64,7 +64,12 @@ resource "azurerm_virtual_machine" "node{{ n }}_vm" {
     }
 
     os_profile_linux_config {
-        disable_password_authentication = false
+        disable_password_authentication = true
+
+        ssh_keys {
+            path     = "{{ node[index].authorized_keys_file }}"
+            key_data = file("{{ node[index].public_key_file }}")
+        }
     }
 
 

--- a/terraform/azure/qdevice.tf.j2
+++ b/terraform/azure/qdevice.tf.j2
@@ -62,7 +62,12 @@ resource "azurerm_virtual_machine" "qdevice_vm" {
     }
 
     os_profile_linux_config {
-        disable_password_authentication = false
+        disable_password_authentication = true
+
+        ssh_keys {
+            path     = "{{ qdevice.authorized_keys_file }}"
+            key_data = file("{{ qdevice.public_key_file }}")
+        }
     }
 
 

--- a/utils.py
+++ b/utils.py
@@ -151,7 +151,7 @@ def sinkable_props_for_provider(name):
         return ["source_image", "volume_name", "cpus", "memory", "disk_size"]
 
     if name == "azure":
-        return ["vm_size", "offer", "sku", "version"]
+        return ["vm_size", "offer", "sku", "version", "authorized_keys_file", "public_key_file"]
 
     return []
 


### PR DESCRIPTION
This is my first terraform commit. As I understand, simply changing the disable_password_authentication state would copy the ssh key automatically, and I don't need to do the provisioning in the deploy.py.